### PR TITLE
Bugfix/sending messages - - New conversation messages not showing, replies not showing, messages ordered incorrectly

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -21,7 +21,7 @@ const Home = ({ user, logout }) => {
 
   const [conversations, setConversations] = useState([]);
   const [activeConversation, setActiveConversation] = useState(null);
-
+  
   const classes = useStyles();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -80,18 +80,20 @@ const Home = ({ user, logout }) => {
 
   const addNewConvo = useCallback(
     (recipientId, message) => {
-      conversations.forEach((convo, index) => {
+      const newConversations = [];
+      conversations.forEach(convo => {
         if (convo.otherUser.id === recipientId) {
-          
-          setConversations(prev => {
-            const newConversations = [...prev];
-            newConversations[index].messages.push(message);
-            newConversations[index].latestMessageText = message.text;
-            newConversations[index].id = message.conversationId;
-            return newConversations;
+          newConversations.push({
+            id: message.conversationId,
+            otherUser: convo.otherUser,
+            messages: [...convo.messages, message],
+            latestMessageTextL: message.text
           });
+        } else {
+          newConversations.push(convo)
         }
       });
+      setConversations(newConversations);
     },
     [setConversations, conversations],
   );
@@ -109,17 +111,20 @@ const Home = ({ user, logout }) => {
         newConvo.latestMessageText = message.text;
         setConversations((prev) => [newConvo, ...prev]);
       }
-      conversations.forEach((convo, index) => {
+      const newConversations = [];
+      conversations.forEach(convo => {
         if (convo.id === message.conversationId) {
-
-          setConversations(prev => {
-            const newConversations = [...prev];
-            newConversations[index].messages.push(message);
-            newConversations[index].latestMessageText = message.text;
-            return newConversations;
+          newConversations.push({
+            id: message.conversationId,
+            otherUser: convo.otherUser,
+            messages: [...convo.messages, message],
+            latestMessageTextL: message.text
           });
+        } else {
+          newConversations.push(convo)
         }
       });
+      setConversations(newConversations);
     },
     [setConversations, conversations],
   );


### PR DESCRIPTION
closes #1 [here](https://github.com/Drumshtick/7c3ae9/issues/1)

## Description
### Messages displayed in incorrect order
* Investigated with _chrome developer tools_
* checked values of messages being displayed
    > **Fixed** reordered messages in ```messages.js``` with a _```Array.sort``` method_

### When a user responds with a message in an existing conversation the message does not show in the conversation
* Investigated with _chrome developer tools and react developer tools_
* state was ok before adding to conversations
* traced execution in ```Home.js``` for sending and adding new message to conversation
* Saw an **improperly handled promise in ```postMessage()```**
     > **Fixed** by _using ```.then()```_ to handle the promise _and ```.catch()```_ to handle error
* Continued to ```addMessageToConversation()```
* Saw execution not getting past the conversations ```.forEach()```
* Noticed state was being altered by mutating state **DIRECTLY**
  > **Fixed** by duplicating state with ```...``` then mutating duplicate before using ```setConversation()``` properly, 

### When the user creates a new conversation by sending an initial message the message is not displayed immediately after
* Investigated with _chrome developer tools_
* traced execution in ```Home.js``` for sending new message in new conversation
* ```postMessage()``` branches to ```addNewConvo()``` for new conversation
* After seeing how state was being updated in ```addMessageToConversation()``` I immediately checked ```setConversation()``` in ```addNewConvo()```, found the error was duplicated here as well
  > **Fixed** by duplicating state with ```...``` then mutating duplicate before using ```setConversation()``` properly, 

## Tests
* All tests passed locally with Cypress